### PR TITLE
Fixes for autograder. add autoreload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# final_proj_faulty_commit_sol
+# final_proj_faulty_commit
+
+The final project for Data C182 Fall 2024.
+
+**For students**: start off by cloning/downloading this repo, uploading to your Google drive, and running the `final_project.ipynb` notebook in Colab.
+
+**Project spec**: https://docs.google.com/document/d/1erKfrMXIY_JkPB_648wyaTXP89Llo4MyD68l_pZRwZo/edit?tab=t.0#heading=h.i522cvq4jmw
+
+Maintainers:
+- Eric Kim (ekim555@berkeley.edu)
+- Naveen Ashish (nashish@berkeley.edu)
+
+# (Internal notes)
+The following is for course staff only.
+
+## Gradescope Autograder
+
+To create the Gradescope autograder, run the following:
+
+```
+cd final_proj_faulty_commit_sol/
+./scripts/create_autograder.sh
+```
+This will create a new file `final_proj_faulty_commit_sol/autograder.zip`, which you will then upload to Gradescope in the "Configure Autograder" section.
+
+## Generate student-facing version
+
+The student-facing github repo (`final_proj_faulty_commit_student`) is generated from the "solution" repo via automated scripts.
+
+To generate the student-facing repo (eg with solutions removed), run the following:
+
+```
+# First, make sure that the `final_proj_faulty_commit_student` repo exists in the following directory structure:
+#   some_parent_dir/final_proj_faulty_commit_student
+#   some_parent_dir/final_proj_faulty_commit_sol
+# Then, run the following:
+cd some_parent_dir/final_proj_faulty_commit_sol
+./scripts/generate_student_version_runner.sh
+
+# This will update `some_parent_dir/final_proj_faulty_commit_student`, so then you will want to commit+push those changes:
+cd ../final_proj_faulty_commit_student
+git checkout -b fa24-yourname-some-name
+git add -A
+git commit -m "Update student-facing code"
+git push origin fa24-yourname-some-name
+
+# Then, click the resulting github link, and merge it into the main branch.
+```
+
+Tip: If you make any changes to the student-facing code (that breaks backwards compatibility) after the project has been released, you should probably make an Ed announcement to tell students to re-download the code/notebook.
+
+Important: anything you push to `final_proj_faulty_commit_student` will be visible to students! So, take extra care when updating this repo. On the other hand, `final_proj_faulty_commit_sol` is a private repo, so students don't have access to this repo.

--- a/final_project.ipynb
+++ b/final_project.ipynb
@@ -32,6 +32,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Important: enable autoreload so that changes to .py files are auto-imported. For convenience.\n",
+    "#   https://ipython.org/ipython-doc/3/config/extensions/autoreload.html\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
     "import seaborn\n",

--- a/tests/evaluation/test_offline_eval.py
+++ b/tests/evaluation/test_offline_eval.py
@@ -97,11 +97,11 @@ class TestComputeEvalMetrics(unittest.TestCase):
         self.assertTrue(np.allclose(eval_metrics.precisions.numpy(), eval_metrics_expected.precisions.numpy(), equal_nan=True))
         self.assertTrue(np.allclose(eval_metrics.recalls.numpy(), eval_metrics_expected.recalls.numpy(), equal_nan=True))
         self.assertTrue(np.allclose(eval_metrics.thresholds.numpy(), eval_metrics_expected.thresholds.numpy(), equal_nan=True))
-        self.assertAlmostEquals(eval_metrics.average_precision, eval_metrics_expected.average_precision)
-        self.assertAlmostEquals(eval_metrics.metrics_op.precision_op, eval_metrics_expected.metrics_op.precision_op)
-        self.assertAlmostEquals(eval_metrics.metrics_op.recall_op, eval_metrics_expected.metrics_op.recall_op)
-        self.assertAlmostEquals(eval_metrics.metrics_op.f1_score_op, eval_metrics_expected.metrics_op.f1_score_op)
-        self.assertAlmostEquals(eval_metrics.metrics_op.threshold_op, eval_metrics_expected.metrics_op.threshold_op)
+        self.assertAlmostEqual(eval_metrics.average_precision, eval_metrics_expected.average_precision)
+        self.assertAlmostEqual(eval_metrics.metrics_op.precision_op, eval_metrics_expected.metrics_op.precision_op)
+        self.assertAlmostEqual(eval_metrics.metrics_op.recall_op, eval_metrics_expected.metrics_op.recall_op)
+        self.assertAlmostEqual(eval_metrics.metrics_op.f1_score_op, eval_metrics_expected.metrics_op.f1_score_op)
+        self.assertAlmostEqual(eval_metrics.metrics_op.threshold_op, eval_metrics_expected.metrics_op.threshold_op)
 
 
 if __name__ == '__main__':

--- a/utils/test_utils.py
+++ b/utils/test_utils.py
@@ -14,4 +14,4 @@ def assert_equal(tester: unittest.TestCase, a, b):
             msg=f"Expected equal: {a} vs {b}"
         )
     else:
-        tester.assertEquals(a, b)
+        tester.assertEqual(a, b)


### PR DESCRIPTION
Fixes for autograder. add autoreload. With this, the Gradescope autograder works (staff sol gets 110/100 pts).

For some reason, `assertEquals` doesn't work in the Gradescope autograder, thus we have to use `assertEqual` instead. Odd.

Corresponds to sol commit: `531c0b0`