### PR TITLE
Fix F1 score unittest

### DIFF
--- a/tests/evaluation/test_offline_eval.py
+++ b/tests/evaluation/test_offline_eval.py
@@ -88,7 +88,7 @@ class TestComputeEvalMetrics(unittest.TestCase):
                 # precision/recall/f1 at the given classification threshold
                 precision_op=0.75,
                 recall_op=1.0,
-                f1_score_op=0.42857142857142855,
+                f1_score_op=0.8571428571428571,
                 # Classification threshold
                 threshold_op=0.5,
             ),


### PR DESCRIPTION
Fix F1 score unittest, we were missing the `2*` part. Corresponds to sol commit: e7a043dcf800072e4b4bfa27af23960c59f66394